### PR TITLE
alloc_fixes.sh with full alpha20 support + undeadlegacy with stable2 mirror support

### DIFF
--- a/scripts/Mods/alloc_fixes.sh
+++ b/scripts/Mods/alloc_fixes.sh
@@ -5,6 +5,8 @@ MODS_FOLDER=/home/sdtdserver/serverfiles/Mods
 # Change DL_LINK depending on 7 days to die branch version
 if [ "${VERSION,,}" == 'stable' ] || [ "${VERSION,,}" == 'public' ]; then
     DL_LINK="http://illy.bz/fi/7dtd/server_fixes.tar.gz"
+elif [ "${VERSION,,}" == 'alpha20' ]; then
+    DL_LINK="http://illy.bz/fi/7dtd/server_fixes.tar.gz"
 elif [ "${VERSION,,}" == 'alpha19.6' ] || [ "${VERSION,,}" == 'alpha19.5' ]; then
     DL_LINK="http://illy.bz/fi/7dtd/server_fixes_v21_23_38.tar.gz"
 elif [ "${VERSION,,}" == 'alpha19.0' ] || [ "${VERSION,,}" == 'alpha19.2' ] || [ "${VERSION,,}" == 'alpha19.3' ] || [ "${VERSION,,}" == 'alpha19.4' ]; then

--- a/scripts/Mods/enZombies.sh
+++ b/scripts/Mods/enZombies.sh
@@ -6,7 +6,6 @@ DL_LINK="https://github.com/ErrorNull0/enZombies/archive/refs/heads/main.zip"
 DL_LINK_SNUFKIN_ADDON="https://github.com/ErrorNull0/enZombiesSnufkinAddon/archive/refs/heads/main.zip"
 DL_LINK_ROBELOTO_ADDON="https://github.com/ErrorNull0/enZombiesRobelotoAddon/archive/refs/heads/main.zip"
 DL_LINK_NONUDES_ADDON="https://github.com/ErrorNull0/enZombiesNoNudes/archive/refs/heads/main.zip"
-DL_LINK_UNDEADLEGACY_PATCH="https://github.com/ErrorNull0/enZombiesUndeadLegacyPatch/archive/refs/heads/main.zip"
 
 downloadRelease() {
     curl "$DL_LINK" -SsL -o enZombies.zip
@@ -22,10 +21,6 @@ downloadRelease_Robeloto() {
 
 downloadRelease_NoNudes() {
     curl "$DL_LINK_NONUDES_ADDON" -SsL -o enZombiesNoNudesAddon.zip
-}
-
-downloadRelease_UndeadLegacy_Patch() {
-    curl "$DL_LINK_UNDEADLEGACY_PATCH" -SsL -o enZombiesUndeadLegacy.zip
 }
 
 echo "[enZombies] Downloading release from ${DL_LINK}"
@@ -128,28 +123,6 @@ if [ "${ENZOMBIES_ADDON_NONUDES,,}" == 'yes' ]; then
 
     rm enZombiesNoNudesAddon.zip
     rm -rf enZombiesNoNudesAddon-temp
-fi
-
-if [ "${UNDEAD_LEGACY,,}" == 'yes' ]; then
-    echo "[enZombies] Downloading Undead Legacy patch from ${DL_LINK_UNDEADLEGACY_PATCH}"
-
-    echo "[enZombies] Downloading Undead Legacy patch files"
-
-    downloadRelease_UndeadLegacy_Patch
-
-    echo "[enZombies] Extracting files"
-
-    mkdir -p enZombiesUndeadLegacy-temp
-    unzip -q enZombiesUndeadLegacy.zip -d enZombiesUndeadLegacy-temp
-
-    echo "[enZombies] Installing components"
-
-    cp -a enZombiesUndeadLegacy-temp/enZombiesUndeadLegacyPatch-main/. $MODS_FOLDER
-
-    echo "[enZombies] Undead Legacy patch Cleanup"
-
-    rm enZombiesUndeadLegacy.zip
-    rm -rf enZombiesUndeadLegacy-temp
 fi
 
 echo "[enZombies] Finished! ヽ(´▽\`)/"

--- a/scripts/Mods/mods_install.sh
+++ b/scripts/Mods/mods_install.sh
@@ -21,11 +21,9 @@ fi
 if [ "${UNDEAD_LEGACY,,}" == 'yes'  ]
   then
     source $scriptsDir/Mods/undead_legacy.sh
-    # To install fix for enZombies with Undead Legacy
-    ENZOMBIES_UL_PATCH=yes
 fi
 
-# Install enZombies + addons always after Undead Legacy, because if installed with Undead Legacy need a patch
+# Install enZombies + addons
 if [ "${ENZOMBIES,,}" == 'yes'  ]
   then
     source $scriptsDir/Mods/enZombies.sh

--- a/scripts/server_update.sh
+++ b/scripts/server_update.sh
@@ -25,7 +25,14 @@ fi
 
 ./sdtdserver update
 
-echo "[INFO] The server have been updated to ${VERSION,,}"
+update_code=$?
+
+if update_code -eq 0
+then
+    echo "[INFO] The server have been updated to ${VERSION,,}"
+else
+	echo "[INFO] There was a problem updating the server to ${VERSION,,}"
+fi
 
 source $scriptsDir/Mods/mods_install.sh
 


### PR DESCRIPTION
*** be aware that scripts/Mods/alloc_fixes.sh is a little bit different than vinanrra one ***

as stream update system support "alpha20.5" naming structure, my alloc_fixes.sh checks if the first 7 char of the version are 
 "alpha20" and not only strictly "alpha20" as alpha20.5 is supported by undeadlegacy but not alpha20.6 (for now).
